### PR TITLE
DRAFT: use more OSGI-way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .idea
 *.iml
 
+/bin/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Base Starter for Vaadin Flow and OSGi
+# Base Starter for Vaadin Flow and OSGi in NPM mode
 
 This project can be used as a starting point to create your own Vaadin Flow application bundle for OSGi.
 It has the necessary dependencies and files to help you get started.
@@ -7,10 +7,10 @@ The best way to use it is via [vaadin.com/start](https://vaadin.com/start) - you
 
 To access it directly from github, clone the repository and import the project to the IDE of your choice as a Maven project. You need to have Java 8 or 11 installed.
 
-Run using `mvn -Pprepare-osgi-container -Prun-osgi-container verify` and open [http://localhost:8080](http://localhost:8080) in browser.
+Run using `mvn -Pprepare-osgi-container -Prun-osgi-container -Pproduction verify` and open [http://localhost:8080](http://localhost:8080) in browser.
 This command will run profiles which downloads for you Felix OSGi container and installs `felix-jetty` 
 as OSGi web container. It deploys all necessary bundles to Felix and start it synchronously.
 The container will be stopped  when you stop your maven build (e.g. by killing it via `Ctrl+C`).
 
 :warning:
-At the moment, Vaadin 14 supports OSGi only in compatibility mode. 
+At the moment, Vaadin 14 supports OSGi only in production mode. 

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,8 +1,0 @@
-Bundle-SymbolicName: ${project.groupId}.osgi.base
-Bundle-Name: Base Starter for Vaadin Flow and OSGi
-Bundle-Version: ${osgi.bundle.version}
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
-Import-Package: *
-Export-Package: !*
-Vaadin-OSGi-Extender: true

--- a/itest.bndrun
+++ b/itest.bndrun
@@ -1,0 +1,85 @@
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1
+    
+-tester: biz.aQute.tester.junit-platform
+
+-runvm: ${def;argLine}
+
+#-resolve.effective: resolve,active
+
+-runproperties: \
+	logback.configurationFile=file:${.}/logback.xml,\
+	org.apache.felix.http.host=localhost,\
+	org.osgi.service.http.port=8080,\
+	org.osgi.framework.bootdelegation=sun.reflect,\
+	osgi.console=
+
+-runblacklist: \
+	bnd.identity;id='osgi.core',\
+	bnd.identity;id='osgi.cmpn',\
+	bnd.identity;id='org.apache.tomcat-embed-core'
+
+#-augment.ph = \
+#	com.helger.ph-commons; \
+#		capability:="osgi.extender; osgi.extender=osgi.serviceloader.registrar, \
+#		osgi.extender; osgi.extender=osgi.serviceloader.processor"
+		
+
+-runsystempackages: \
+	org.slf4j;version=1.7.25,\
+	org.slf4j.helpers;version=1.7.25,\
+	org.slf4j.spi;version=1.7.25
+-runpath: \
+	ch.qos.logback.classic,\
+	ch.qos.logback.core,\
+	org.apache.felix.logback,\
+	slf4j.api
+-runrequires.default: \
+	bnd.identity;id='com.example.osgi.base',\
+	bnd.identity;id='com.example.osgi.base-tests',\
+	bnd.identity;id='junit-jupiter-engine',\
+	bnd.identity;id='junit-platform-launcher'
+# Please try and keep this sorted to make diffing more consistent
+-runee: JavaSE-11
+-runfw: org.apache.felix.framework
+-runbundles: \
+	biz.aQute.bndlib;version='[5.0.1,5.0.2)',\
+	com.example.osgi.base;version='[1.0.0,1.0.1)',\
+	com.example.osgi.base-tests;version='[1.0.0,1.0.1)',\
+	com.helger.ph-commons;version='[9.1.2,9.1.3)',\
+	com.helger.ph-css;version='[6.1.1,6.1.2)',\
+	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
+	com.vaadin.external.gentyref;version='[1.2.0,1.2.1)',\
+	com.vaadin.external.gwt;version='[2.8.2,2.8.3)',\
+	com.vaadin.flow.component.button;version='[2.2.0,2.2.1)',\
+	com.vaadin.flow.component.notification;version='[2.2.0,2.2.1)',\
+	com.vaadin.flow.component.orderedlayout;version='[2.3.0,2.3.1)',\
+	com.vaadin.flow.osgi;version='[2.5.0,2.5.1)',\
+	com.vaadin.flow.server;version='[2.5.0,2.5.1)',\
+	com.vaadin.flow.theme.lumo;version='[2.4.0,2.4.1)',\
+	jaxb-api;version='[2.2.7,2.2.8)',\
+	junit-jupiter-api;version='[5.6.2,5.6.3)',\
+	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
+	junit-platform-commons;version='[1.7.0,1.7.1)',\
+	junit-platform-engine;version='[1.7.0,1.7.1)',\
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	net.bytebuddy.byte-buddy;version='[1.10.9,1.10.10)',\
+	org.apache.aries.spifly.dynamic.bundle;version='[1.3.0,1.3.1)',\
+	org.apache.commons.commons-compress;version='[1.19.0,1.19.1)',\
+	org.apache.commons.fileupload;version='[1.3.3,1.3.4)',\
+	org.apache.commons.io;version='[2.5.0,2.5.1)',\
+	org.apache.commons.logging;version='[1.2.0,1.2.1)',\
+	org.apache.felix.configadmin;version='[1.9.18,1.9.19)',\
+	org.apache.felix.http.jetty;version='[4.1.0,4.1.1)',\
+	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+	org.apache.felix.scr;version='[2.1.24,2.1.25)',\
+	org.apache.httpcomponents.httpclient;version='[4.5.2,4.5.3)',\
+	org.apache.httpcomponents.httpcore;version='[4.4.4,4.4.5)',\
+	org.jsoup;version='[1.12.1,1.12.2)',\
+	org.objectweb.asm;version='[8.0.1,8.0.2)',\
+	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
+	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
+	org.objectweb.asm.tree.analysis;version='[8.0.1,8.0.2)',\
+	org.objectweb.asm.util;version='[8.0.1,8.0.2)',\
+	org.opentest4j;version='[1.2.0,1.2.1)'

--- a/logback.xml
+++ b/logback.xml
@@ -1,0 +1,35 @@
+<!--
+/**
+ * Copyright (c) OSGi Alliance (2019). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4relative [%.15thread] %-5level %logger{36}:%line - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.osgi.test" level="DEBUG"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>14.2.1</vaadin.version>
+        <vaadin.version>14.4.0.rc1</vaadin.version>
 
         <felix.version>6.0.0</felix.version>
         <felix.distribution>https://repo1.maven.org/maven2/org/apache/felix/org.apache.felix.main.distribution/${felix.version}/org.apache.felix.main.distribution-${felix.version}.zip</felix.distribution>
@@ -30,6 +30,10 @@
         <repository>
             <id>vaadin-prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
+        </repository>
+        <repository>
+            <id>vaadin-prereleases-snapshots</id>
+            <url>http://tools.vaadin.com/nexus/content/repositories/vaadin-prereleases</url>
         </repository>
         <repository>
             <id>vaadin-snapshots</id>
@@ -71,7 +75,39 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-osgi</artifactId>
+            <version>2.5.osgi-SNAPSHOT</version>
         </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>2.5.osgi-SNAPSHOT</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-data</artifactId>
+            <version>2.5.osgi-SNAPSHOT</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>2.5.osgi-SNAPSHOT</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+            <version>2.5.osgi-SNAPSHOT</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-push</artifactId>
+            <version>2.5.osgi-SNAPSHOT</version>
+        </dependency>
+        
 
         <dependency>
             <groupId>org.osgi</groupId>
@@ -112,7 +148,7 @@
 
     <build>
         <plugins>
-            <plugin>
+        <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.0.0</version>
@@ -122,21 +158,6 @@
                         <goals>
                             <goal>parse-version</goal>
                         </goals>
-                    </execution>
-                    <execution>
-                        <id>add-resource</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>add-resource</goal>
-                        </goals>
-                        <configuration>
-                            <resources>
-                                <resource>
-                                    <directory>${project.build.directory}/generated-resources</directory>
-                                    <targetPath></targetPath>
-                                </resource>
-                            </resources>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -166,43 +187,14 @@
                     </archive>
                 </configuration>
             </plugin>
-
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <version>${vaadin.version}</version>
                 <executions>
                     <execution>
-                        <id>unpack-dependencies</id>
-                        <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/webjars/**</includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
-                    <execution>
-                        <id>copy-frontend</id>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <tasks>
-                                <mkdir
-                                    dir="${project.build.directory}/generated-resources/frontend/bower_components"></mkdir>
-                                <copy
-                                    todir="${project.build.directory}/generated-resources/frontend/bower_components">
-                                    <fileset
-                                        dir="${project.build.directory}/dependency/META-INF/resources/webjars/" />
-                                </copy>
-                            </tasks>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
+                            <goal>prepare-frontend</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -254,7 +246,7 @@
                 <vaadin.productionMode>true</vaadin.productionMode>
             </properties>
 
-            <dependencies>
+             <dependencies>
                 <dependency>
                     <groupId>com.vaadin</groupId>
                     <artifactId>flow-server-production-mode</artifactId>
@@ -270,9 +262,9 @@
                         <executions>
                             <execution>
                                 <goals>
-                                    <goal>copy-production-files</goal>
-                                    <goal>package-for-production</goal>
+                                    <goal>build-frontend</goal>
                                 </goals>
+                                <phase>compile</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
     <artifactId>project-base-osgi</artifactId>
@@ -14,10 +12,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vaadin.version>14.4.0.rc1</vaadin.version>
-
-        <felix.version>6.0.0</felix.version>
-        <felix.distribution>https://repo1.maven.org/maven2/org/apache/felix/org.apache.felix.main.distribution/${felix.version}/org.apache.felix.main.distribution-${felix.version}.zip</felix.distribution>
-        <felix.home>felix-framework-${felix.version}</felix.home>
+        <bnd.version>5.2.0-SNAPSHOT</bnd.version>
+        <osgi-test.version>0.10.0</osgi-test.version>
+        <junit-jupiter.version>5.6.2</junit-jupiter.version>
+        <junit-platform.version>1.7.0</junit-platform.version>
         <osgi.bundle.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</osgi.bundle.version>
     </properties>
 
@@ -67,84 +65,295 @@
             <artifactId>vaadin</artifactId>
         </dependency>
 
-   
+
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-osgi</artifactId>
             <version>2.5.osgi-SNAPSHOT</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>2.5.osgi-SNAPSHOT</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-data</artifactId>
             <version>2.5.osgi-SNAPSHOT</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-client</artifactId>
             <version>2.5.osgi-SNAPSHOT</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components</artifactId>
             <version>2.5.osgi-SNAPSHOT</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-push</artifactId>
             <version>2.5.osgi-SNAPSHOT</version>
         </dependency>
-        
+
 
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.cmpn</artifactId>
             <version>7.0.0</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
             <version>6.0.0</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
 
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.2.3</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- Added to provide logging output as Flow uses -->
         <!-- the unbound SLF4J no-operation (NOP) logger implementation -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <version>6.0.3</version>
+            <scope>runtime</scope>
+        </dependency>
+
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr</artifactId>
+            <version>2.1.24</version>
+            <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.log</artifactId>
+            <version>1.2.4</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+            <version>1.9.18</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.annotations</artifactId>
+            <version>1.12.0</version>
+            <!-- <scope>provided</scope> -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.compat</artifactId>
+            <version>1.0.4</version>
+            <!-- <scope>provided</scope> -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <version>1.2.10</version>
+            <!-- <scope>provided</scope> -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.servlet-api</artifactId>
+            <version>1.1.2</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.jetty</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <!-- Those dependencies are need for OSGi container where this bundle will be deployed. They will be copied into the bundle folder of OSGi container and automatically installed form there. -->
+
+        <!-- <dependency> -->
+        <!-- <groupId>org.osgi</groupId> -->
+        <!-- <artifactId>org.osgi.service.serviceloader</artifactId> -->
+        <!-- <version>1.0.0</version> -->
+        <!-- </dependency> -->
+
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.static.bundle</artifactId>
+            <version>1.3.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.static.tool</artifactId>
+            <version>1.3.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.core-internal</artifactId>
+            <version>1.3.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.weaver-internal</artifactId>
+            <version>1.3.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries</groupId>
+            <artifactId>org.apache.aries.util</artifactId>
+            <version>1.1.3</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+            <version>1.3.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Start iTest -->
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.junit</artifactId>
+            <version>4.12_1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.4.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.16.1</version>
+        </dependency>
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.tester.junit-platform</artifactId>
+            <version>5.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
+            <version>${junit-platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <version>${junit-platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit-platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+            <version>${junit-platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.test.common</artifactId>
+            <version>${osgi-test.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.test.junit5</artifactId>
+            <version>${osgi-test.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.test.junit5.cm</artifactId>
+            <version>${osgi-test.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.test.assertj.framework</artifactId>
+            <version>${osgi-test.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.test.assertj.promise</artifactId>
+            <version>${osgi-test.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.logback</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <!-- End iTest -->
+
 
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
             <version>1.5.0</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>
 
     <build>
         <plugins>
-        <plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.0.0</version>
@@ -169,6 +378,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- start build jar -->
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>${bnd.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <bnd><![CDATA[
+                Bundle-SymbolicName: com.example.osgi.base
+Bundle-Name: Base Starter for Vaadin Flow and OSGi
+Bundle-Version: ${osgi.bundle.version}
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
+Import-Package: *
+Export-Package: !*
+Vaadin-OSGi-Extender: true]]>
+                    </bnd>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -183,6 +417,132 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!-- end start build jar -->
+            <!-- start build test jar -->
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>${bnd.version}</version>
+                <executions>
+                    <!-- Integration Test Configuration -->
+                    <execution>
+                        <id>bnd-process-tests</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>bnd-process-tests</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+Bundle-SymbolicName: com.example.osgi.base-tests
+Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
+Git-Descriptor: ${system-allow-fail;git describe --dirty --always --abbrev=9}
+Git-SHA:        ${system-allow-fail;git rev-list -1 --no-abbrev-commit HEAD}
+-sources: false
+-contract: *
+]]></bnd>
+                            <testCases>junit5</testCases><!-- default is junit5 -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Required to make the maven-jar-plugin pick up the bnd generated manifest. Also avoid packaging empty Jars -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- end build test jar -->
+
+
+            <!-- start resolve -->
+
+            <!-- This dynamically calculates all the things we need to run our code. -->
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-resolver-maven-plugin</artifactId>
+                <version>${bnd.version}</version>
+                <executions>
+                    <!-- Integration Test Configuration -->
+                    <execution>
+                        <id>resolve-test</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>resolve</goal>
+                        </goals>
+                        <configuration>
+                            <bndruns>
+                                <bndrun>itest.bndrun</bndrun>
+                            </bndruns>
+                            <bundles>
+                                <bundle>target/${project.build.finalName}-tests.jar</bundle>
+                            </bundles>
+                            <failOnChanges>false</failOnChanges>
+                            <includeDependencyManagement>true</includeDependencyManagement>
+                            <reportOptional>false</reportOptional>
+                            <scopes>
+                                <scope>compile</scope>
+                                <scope>runtime</scope>
+                                <scope>test</scope>
+                            </scopes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- end resolve -->
+            <!-- start integration-test -->
+            <!-- Define the version of the testing plugin that we use -->
+
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-testing-maven-plugin</artifactId>
+                <version>${bnd.version}</version>
+                <executions>
+                    <execution>
+                        <!-- <phase>test</phase> -->
+                        <goals>
+                            <goal>testing</goal>
+                        </goals>
+                        <configuration>
+                            <bndruns>
+                                <bndrun>itest.bndrun</bndrun>
+                            </bndruns>
+                            <bundles>
+                                <bundle>target/${project.build.finalName}-tests.jar</bundle>
+                            </bundles>
+                            <failOnChanges>false</failOnChanges>
+                            <includeDependencyManagement>true</includeDependencyManagement>
+                            <resolve>true</resolve>
+                            <scopes>
+                                <scope>compile</scope>
+                                <scope>runtime</scope>
+                                <scope>test</scope>
+                            </scopes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <!-- end integration-test -->
+
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-maven-plugin</artifactId>
@@ -198,8 +558,7 @@
         </plugins>
         <pluginManagement>
             <plugins>
-                <!--This plugin's configuration is used to store Eclipse 
-                    m2e settings only. It has no influence on the Maven build itself. -->
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -242,7 +601,7 @@
                 <vaadin.productionMode>true</vaadin.productionMode>
             </properties>
 
-             <dependencies>
+            <dependencies>
                 <dependency>
                     <groupId>com.vaadin</groupId>
                     <artifactId>flow-server-production-mode</artifactId>
@@ -268,204 +627,11 @@
             </build>
         </profile>
         <profile>
-            <id>prepare-osgi-container</id>
-            <dependencies>
-
-                <dependency>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>org.apache.felix.scr</artifactId>
-                    <version>2.1.10</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>org.apache.felix.scr.annotations</artifactId>
-                    <version>1.12.0</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>org.apache.felix.scr.compat</artifactId>
-                    <version>1.0.4</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
-                    <version>1.2.10</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>org.apache.felix.http.servlet-api</artifactId>
-                    <version>1.1.2</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>org.apache.felix.http.jetty</artifactId>
-                    <version>4.0.6</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <!-- Those dependencies are need for OSGi container where 
-                    this bundle will be deployed. They will be copied into the bundle folder 
-                    of OSGi container and automatically installed form there. -->
-
-                <dependency>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.service.serviceloader</artifactId>
-                    <version>1.0.0</version>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.aries.spifly</groupId>
-                    <artifactId>org.apache.aries.spifly.static.bundle</artifactId>
-                    <version>1.0.12</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.aries.spifly</groupId>
-                    <artifactId>org.apache.aries.spifly.static.tool</artifactId>
-                    <version>1.0.12</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.aries.spifly</groupId>
-                    <artifactId>org.apache.aries.spifly.core-internal</artifactId>
-                    <version>1.0.12</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.aries.spifly</groupId>
-                    <artifactId>org.apache.aries.spifly.weaver-internal</artifactId>
-                    <version>1.0.12</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.aries</groupId>
-                    <artifactId>org.apache.aries.util</artifactId>
-                    <version>1.1.3</version>
-                    <scope>provided</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.apache.aries.spifly</groupId>
-                    <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-                    <version>1.0.12</version>
-                    <scope>provided</scope>
-                </dependency>
-
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>download-files</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <tasks>
-                                        <get
-                                            src="${felix.distribution}"
-                                            dest="${project.build.directory}/felix.zip"
-                                            verbose="false"
-                                            usetimestamp="true" />
-                                        <unzip
-                                            src="${project.build.directory}/felix.zip"
-                                            dest="${project.build.directory}"></unzip>
-                                    </tasks>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>copy-self</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <tasks>
-                                        <copy
-                                            todir="${project.build.directory}/${felix.home}/bundle"
-                                            file="${project.build.directory}/${project.artifactId}-${project.version}.jar">
-                                        </copy>
-                                    </tasks>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.1.1</version>
-                        <executions>
-                            <execution>
-                                <id>copy-dependencies</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>copy-dependencies</goal>
-                                </goals>
-                                <configuration>
-                                    <includeScope>compile</includeScope>
-                                    <outputDirectory>${project.build.directory}/${felix.home}/bundle</outputDirectory>
-                                    <overWriteIfNewer>true</overWriteIfNewer>
-                                    <excludeGroupIds>com.google.code.findbugs,
-                                        org.seleniumhq.selenium,
-                                        javax.servlet</excludeGroupIds>
-                                    <excludeArtifactIds>osgi.cmpn</excludeArtifactIds>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>run-osgi-container</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
-                        <executions>
-                            <execution>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>java</executable>
-                                    <workingDirectory>${project.build.directory}/${felix.home}</workingDirectory>
-                                    <commandlineArgs>-Dgosh.args="--nointeractive"
-                                        -jar bin/felix.jar</commandlineArgs>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>java11</id>
-            <!-- Java 11 has no built-in "jaxb" and "activation" packages so they should
-                 be provided as dependencies to be able to resolve bundles which depends on them -->
+            <!-- Java 11 has no built-in "jaxb" and "activation" packages so they should be provided as dependencies to be able to resolve bundles which depends on them -->
             <activation>
-                <jdk>11</jdk>
+                <!-- <jdk>11</jdk> -->
+                <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,6 @@
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
         <repository>
-            <id>vaadin-prereleases-snapshots</id>
-            <url>http://tools.vaadin.com/nexus/content/repositories/vaadin-prereleases</url>
-        </repository>
-        <repository>
             <id>vaadin-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
         </repository>

--- a/src/main/java/com/example/starter/base/osgi/VaadinServletRegistration.java
+++ b/src/main/java/com/example/starter/base/osgi/VaadinServletRegistration.java
@@ -1,7 +1,7 @@
 package com.example.starter.base.osgi;
 
-import com.vaadin.flow.function.DeploymentConfiguration;
 import java.util.Hashtable;
+import java.util.Properties;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletConfig;
@@ -10,18 +10,24 @@ import javax.servlet.ServletException;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.HttpService;
+import org.osgi.service.http.NamespaceException;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.DefaultDeploymentConfiguration;
+import com.vaadin.flow.server.DeploymentConfigurationFactory;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinServletConfiguration;
-import java.util.Properties;
-import javax.servlet.annotation.WebServlet;
 
 /**
  * Register a VaadinServlet via HTTP Whiteboard specification
  */
 @Component(immediate = true)
 public class VaadinServletRegistration {
+
+    private HttpService httpService;
 
     /**
      * This class is a workaround for #4367. This will be removed after the
@@ -36,24 +42,61 @@ public class VaadinServletRegistration {
         }
 
         @Override
-        protected DeploymentConfiguration createDeploymentConfiguration(Properties initParameters) {
-            // npm mode is not currently supported
-            initParameters.setProperty("compatibilityMode", "true");
-            return super.createDeploymentConfiguration(initParameters);
+        protected DeploymentConfiguration createDeploymentConfiguration(
+                Properties initParameters) {
+            initParameters.remove(
+                    DeploymentConfigurationFactory.DEV_MODE_ENABLE_STRATEGY);
+            initParameters.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE,
+                    true);
+            DeploymentConfiguration config = new DefaultDeploymentConfiguration(
+                    getClass(), initParameters) {
+                @Override
+                public boolean isProductionMode() {
+                    return true;
+                }
+
+                @Override
+                public boolean isStatsExternal() {
+                    return true;
+                }
+
+                @Override
+                public String getExternalStatsUrl() {
+                    return "/VAADIN/config/stats.json";
+                }
+            };
+
+            return config;
         }
-        
+
     }
 
     @Activate
-    void activate(BundleContext ctx) {
+    void activate(BundleContext ctx) throws NamespaceException {
         Hashtable<String, Object> properties = new Hashtable<>();
         properties.put(
                 HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ASYNC_SUPPORTED,
                 true);
+        properties.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                false);
+        properties.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, true);
         properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN,
                 "/*");
         ctx.registerService(Servlet.class, new FixedVaadinServlet(),
                 properties);
+
+        httpService.registerResources("/VAADIN/config/stats.json",
+                "/META-INF/VAADIN/config/stats.json",
+                httpService.createDefaultHttpContext());
+    }
+
+    @Reference
+    void setHttpService(HttpService service) {
+        this.httpService = service;
+    }
+
+    void unsetHttpService(HttpService service) {
+        this.httpService = null;
     }
 
 }


### PR DESCRIPTION
* bnd resolve
* bnd itegration-test
* osgi-test-tools
* junit5



State:
resolve OK
start framework OK
run jetty OK
run vaadin NOT

```
com.vaadin.flow.server.BootstrapException: Unable to read webpack stats file.
	at com.vaadin.flow.server.BootstrapHandler$BootstrapPageBuilder.setupFrameworkLibraries(BootstrapHandler.java:894)
	at com.vaadin.flow.server.BootstrapHandler$BootstrapPageBuilder.setupDocumentHead(BootstrapHandler.java:771)
	at com.vaadin.flow.server.BootstrapHandler$BootstrapPageBuilder.getBootstrapPage(BootstrapHandler.java:540)
	at com.vaadin.flow.server.BootstrapHandler.synchronizedHandleRequest(BootstrapHandler.java:481)
	at com.vaadin.flow.server.SynchronizedRequestHandler.handleRequest(SynchronizedRequestHandler.java:40)
	at com.vaadin.flow.server.VaadinService.handleRequest(VaadinService.java:1545)
	at com.vaadin.flow.server.VaadinServlet.service(VaadinServlet.java:247)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:725)
	at org.apache.felix.http.base.internal.handler.ServletHandler.handle(ServletHandler.java:123)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:86)
	at org.apache.felix.http.base.internal.dispatch.Dispatcher$1.doFilter(Dispatcher.java:146)
	at org.apache.felix.http.base.internal.whiteboard.WhiteboardManager.invokePreprocessors(WhiteboardManager.java:988)
	at org.apache.felix.http.base.internal.dispatch.Dispatcher.dispatch(Dispatcher.java:91)
	at org.apache.felix.http.base.internal.dispatch.DispatcherServlet.service(DispatcherServlet.java:49)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:725)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:763)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:569)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1610)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1377)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:507)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1580)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1292)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:191)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:501)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.io.IOException: The stats file from webpack (stats.json) was not found.
The application is running in production mode.Verify that build-frontend task has executed successfully and that stats.json is on the classpath.Or switch application to development mode.
	at com.vaadin.flow.server.BootstrapHandler$BootstrapPageBuilder.appendNpmBundle(BootstrapHandler.java:926)
	at com.vaadin.flow.server.BootstrapHandler$BootstrapPageBuilder.setupFrameworkLibraries(BootstrapHandler.java:892)
	... 44 common frames omitted```



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-flow-osgi/93)
<!-- Reviewable:end -->
